### PR TITLE
chore: add integration test to validate docker-compose

### DIFF
--- a/.github/workflows/docker-compose-integration.yml
+++ b/.github/workflows/docker-compose-integration.yml
@@ -37,7 +37,6 @@ jobs:
       run: |
         # Test sticker award API with sample user data
         curl -f -X GET "http://localhost:8080/api/award/v1/users/user-001/stickers" || exit 1
-        # Test user management health endpoint
         # TODO!
         # curl -f -X GET "http://localhost:8080/api/users/v1/health" || exit 1
       

--- a/.github/workflows/user-management-test.yml
+++ b/.github/workflows/user-management-test.yml
@@ -3,8 +3,12 @@ name: User Management Tests
 on:
   push:
     branches: ["main"]
+    paths:
+      - "user-management/**"
   pull_request:
     branches: ["main"]
+    paths:
+      - "user-management/**"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Builds and fires up our `docker-compose` to check that our test URLs run. An integration test for our local dev environment. I've also changed the user-service workflow to only fire PR builds if its subdirectory is touched.

The test URLs for user-service i'm struggling with; we can sort this out after the enormous @jeastham1993 PR is merged!
