### PR TITLE
feat(award-service): sticker-award to return structured errors according to spec

### DIFF
--- a/sticker-award/src/main/java/com/datadoghq/stickerlandia/stickeraward/common/dto/ProblemDetails.java
+++ b/sticker-award/src/main/java/com/datadoghq/stickerlandia/stickeraward/common/dto/ProblemDetails.java
@@ -1,0 +1,133 @@
+package com.datadoghq.stickerlandia.stickeraward.common.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
+
+/** RFC 7807 Problem Details for HTTP APIs. */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ProblemDetails {
+    @JsonProperty("type")
+    private String type;
+
+    @JsonProperty("title")
+    private String title;
+
+    @JsonProperty("status")
+    private Integer status;
+
+    @JsonProperty("detail")
+    private String detail;
+
+    @JsonProperty("instance")
+    private String instance;
+
+    private Map<String, Object> additionalProperties;
+
+    /** Default constructor. */
+    public ProblemDetails() {}
+
+    /**
+     * Constructor with status and title.
+     *
+     * @param status HTTP status code
+     * @param title brief, human-readable message
+     */
+    public ProblemDetails(int status, String title) {
+        this.status = status;
+        this.title = title;
+    }
+
+    /**
+     * Constructor with status, title, and detail.
+     *
+     * @param status HTTP status code
+     * @param title brief, human-readable message
+     * @param detail human-readable explanation
+     */
+    public ProblemDetails(int status, String title, String detail) {
+        this.status = status;
+        this.title = title;
+        this.detail = detail;
+    }
+
+    /**
+     * Constructor with type, status, title, and detail.
+     *
+     * @param type URI reference that identifies the problem type
+     * @param status HTTP status code
+     * @param title brief, human-readable message
+     * @param detail human-readable explanation
+     */
+    public ProblemDetails(String type, int status, String title, String detail) {
+        this.type = type;
+        this.status = status;
+        this.title = title;
+        this.detail = detail;
+    }
+
+    /**
+     * Full constructor with all RFC 7807 fields.
+     *
+     * @param type URI reference that identifies the problem type
+     * @param status HTTP status code
+     * @param title brief, human-readable message
+     * @param detail human-readable explanation
+     * @param instance URI reference that identifies the specific occurrence
+     */
+    public ProblemDetails(String type, int status, String title, String detail, String instance) {
+        this.type = type;
+        this.status = status;
+        this.title = title;
+        this.detail = detail;
+        this.instance = instance;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public Integer getStatus() {
+        return status;
+    }
+
+    public void setStatus(Integer status) {
+        this.status = status;
+    }
+
+    public String getDetail() {
+        return detail;
+    }
+
+    public void setDetail(String detail) {
+        this.detail = detail;
+    }
+
+    public String getInstance() {
+        return instance;
+    }
+
+    public void setInstance(String instance) {
+        this.instance = instance;
+    }
+
+    public Map<String, Object> getAdditionalProperties() {
+        return additionalProperties;
+    }
+
+    public void setAdditionalProperties(Map<String, Object> additionalProperties) {
+        this.additionalProperties = additionalProperties;
+    }
+}

--- a/sticker-award/src/main/java/com/datadoghq/stickerlandia/stickeraward/common/exception/ProblemDetailsExceptionMapper.java
+++ b/sticker-award/src/main/java/com/datadoghq/stickerlandia/stickeraward/common/exception/ProblemDetailsExceptionMapper.java
@@ -1,0 +1,40 @@
+package com.datadoghq.stickerlandia.stickeraward.common.exception;
+
+import com.datadoghq.stickerlandia.stickeraward.common.dto.ProblemDetails;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
+/** JAX-RS exception mapper for WebApplicationException to RFC 7807 ProblemDetails. */
+@Provider
+public class ProblemDetailsExceptionMapper implements ExceptionMapper<WebApplicationException> {
+
+    private static final String PROBLEM_JSON_TYPE = "application/problem+json";
+
+    @Override
+    public Response toResponse(WebApplicationException exception) {
+        int status = exception.getResponse().getStatus();
+        String title = getDefaultTitle(status);
+        String detail = exception.getMessage();
+
+        ProblemDetails problemDetails = new ProblemDetails(status, title, detail);
+
+        return Response.status(status)
+                .entity(problemDetails)
+                .header("Content-Type", PROBLEM_JSON_TYPE)
+                .build();
+    }
+
+    private String getDefaultTitle(int status) {
+        return switch (status) {
+            case 400 -> "Bad Request";
+            case 401 -> "Unauthorized";
+            case 403 -> "Forbidden";
+            case 404 -> "Not Found";
+            case 409 -> "Conflict";
+            case 500 -> "Internal Server Error";
+            default -> "Error";
+        };
+    }
+}

--- a/sticker-award/src/main/java/com/datadoghq/stickerlandia/stickeraward/common/exception/ProblemDetailsResponseBuilder.java
+++ b/sticker-award/src/main/java/com/datadoghq/stickerlandia/stickeraward/common/exception/ProblemDetailsResponseBuilder.java
@@ -1,0 +1,43 @@
+package com.datadoghq.stickerlandia.stickeraward.common.exception;
+
+import com.datadoghq.stickerlandia.stickeraward.common.dto.ProblemDetails;
+import jakarta.ws.rs.core.Response;
+
+/** Utility class for building RFC 7807 ProblemDetails HTTP responses. */
+public class ProblemDetailsResponseBuilder {
+
+    private static final String PROBLEM_JSON_TYPE = "application/problem+json";
+
+    public static Response badRequest(String detail) {
+        return buildResponse(400, "Bad Request", detail);
+    }
+
+    public static Response unauthorized(String detail) {
+        return buildResponse(401, "Unauthorized", detail);
+    }
+
+    public static Response forbidden(String detail) {
+        return buildResponse(403, "Forbidden", detail);
+    }
+
+    public static Response notFound(String detail) {
+        return buildResponse(404, "Not Found", detail);
+    }
+
+    public static Response conflict(String detail) {
+        return buildResponse(409, "Conflict", detail);
+    }
+
+    public static Response internalServerError(String detail) {
+        return buildResponse(500, "Internal Server Error", detail);
+    }
+
+    private static Response buildResponse(int status, String title, String detail) {
+        ProblemDetails problemDetails = new ProblemDetails(status, title, detail);
+
+        return Response.status(status)
+                .entity(problemDetails)
+                .header("Content-Type", PROBLEM_JSON_TYPE)
+                .build();
+    }
+}

--- a/sticker-award/src/main/java/com/datadoghq/stickerlandia/stickeraward/sticker/StickerResource.java
+++ b/sticker-award/src/main/java/com/datadoghq/stickerlandia/stickeraward/sticker/StickerResource.java
@@ -1,5 +1,6 @@
 package com.datadoghq.stickerlandia.stickeraward.sticker;
 
+import com.datadoghq.stickerlandia.stickeraward.common.exception.ProblemDetailsResponseBuilder;
 import com.datadoghq.stickerlandia.stickeraward.sticker.dto.CreateStickerRequest;
 import com.datadoghq.stickerlandia.stickeraward.sticker.dto.CreateStickerResponse;
 import com.datadoghq.stickerlandia.stickeraward.sticker.dto.GetAllStickersResponse;
@@ -75,7 +76,8 @@ public class StickerResource {
     public Response getStickerMetadata(@PathParam("stickerId") String stickerId) {
         StickerDTO metadata = stickerRepository.getStickerMetadata(stickerId);
         if (metadata == null) {
-            return Response.status(Response.Status.NOT_FOUND).build();
+            return ProblemDetailsResponseBuilder.notFound(
+                    "Sticker with ID " + stickerId + " not found");
         }
         return Response.ok(metadata).build();
     }
@@ -96,7 +98,8 @@ public class StickerResource {
             @PathParam("stickerId") String stickerId, @NotNull UpdateStickerRequest data) {
         StickerDTO updated = stickerRepository.updateStickerMetadata(stickerId, data);
         if (updated == null) {
-            return Response.status(Response.Status.NOT_FOUND).build();
+            return ProblemDetailsResponseBuilder.notFound(
+                    "Sticker with ID " + stickerId + " not found");
         }
         return Response.ok(updated).build();
     }
@@ -114,13 +117,13 @@ public class StickerResource {
         try {
             boolean deleted = stickerRepository.deleteSticker(stickerId);
             if (!deleted) {
-                return Response.status(Response.Status.NOT_FOUND).build();
+                return ProblemDetailsResponseBuilder.notFound(
+                        "Sticker with ID " + stickerId + " not found");
             }
             return Response.noContent().build();
         } catch (IllegalStateException e) {
-            return Response.status(Response.Status.BAD_REQUEST)
-                    .entity("Cannot delete sticker that is assigned to users")
-                    .build();
+            return ProblemDetailsResponseBuilder.badRequest(
+                    "Cannot delete sticker that is assigned to users");
         }
     }
 
@@ -137,22 +140,21 @@ public class StickerResource {
     public Response getStickerImage(@PathParam("stickerId") String stickerId) {
         StickerDTO metadata = stickerRepository.getStickerMetadata(stickerId);
         if (metadata == null) {
-            return Response.status(Response.Status.NOT_FOUND).build();
+            return ProblemDetailsResponseBuilder.notFound(
+                    "Sticker with ID " + stickerId + " not found");
         }
 
         if (metadata.getImageKey() == null) {
-            return Response.status(Response.Status.NOT_FOUND)
-                    .entity("No image found for this sticker")
-                    .build();
+            return ProblemDetailsResponseBuilder.notFound(
+                    "No image found for sticker " + stickerId);
         }
 
         try {
             InputStream imageStream = stickerImageService.getImage(metadata.getImageKey());
             return Response.ok(imageStream).type("image/png").build();
         } catch (Exception e) {
-            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
-                    .entity("Failed to retrieve image")
-                    .build();
+            return ProblemDetailsResponseBuilder.internalServerError(
+                    "Failed to retrieve image for sticker " + stickerId);
         }
     }
 
@@ -172,7 +174,8 @@ public class StickerResource {
             @PathParam("stickerId") String stickerId, @NotNull InputStream data) {
         StickerDTO metadata = stickerRepository.getStickerMetadata(stickerId);
         if (metadata == null) {
-            return Response.status(Response.Status.NOT_FOUND).build();
+            return ProblemDetailsResponseBuilder.notFound(
+                    "Sticker with ID " + stickerId + " not found");
         }
 
         try {
@@ -195,9 +198,8 @@ public class StickerResource {
             return Response.ok(response).build();
         } catch (Exception e) {
             System.out.println(e);
-            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
-                    .entity("Failed to upload image")
-                    .build();
+            return ProblemDetailsResponseBuilder.internalServerError(
+                    "Failed to upload image for sticker " + stickerId);
         }
     }
 }

--- a/sticker-award/src/test/java/com/datadoghq/stickerlandia/stickeraward/StickerAwardResourceTest.java
+++ b/sticker-award/src/test/java/com/datadoghq/stickerlandia/stickeraward/StickerAwardResourceTest.java
@@ -144,7 +144,11 @@ class StickerAwardResourceTest {
                 .when()
                 .post("/api/awards/v1/assignments/{userId}", userId)
                 .then()
-                .statusCode(400);
+                .statusCode(400)
+                .contentType("application/problem+json")
+                .body("status", is(400))
+                .body("title", is("Bad Request"))
+                .body("detail", is("Invalid request or sticker assignment failed"));
     }
 
     @Test
@@ -171,7 +175,15 @@ class StickerAwardResourceTest {
                 .when()
                 .post("/api/awards/v1/assignments/{userId}", userId)
                 .then()
-                .statusCode(409);
+                .statusCode(409)
+                .contentType("application/problem+json")
+                .body("status", is(409))
+                .body("title", is("Conflict"))
+                .body(
+                        "detail",
+                        is(
+                                "Sticker assignment conflict: "
+                                        + "User already has this sticker assigned"));
     }
 
     @Test
@@ -219,6 +231,16 @@ class StickerAwardResourceTest {
         given().when()
                 .delete("/api/awards/v1/assignments/{userId}/{stickerId}", userId, stickerId)
                 .then()
-                .statusCode(404);
+                .statusCode(404)
+                .contentType("application/problem+json")
+                .body("status", is(404))
+                .body("title", is("Not Found"))
+                .body(
+                        "detail",
+                        is(
+                                "Sticker assignment not found for user "
+                                        + userId
+                                        + " and sticker "
+                                        + stickerId));
     }
 }

--- a/sticker-award/src/test/java/com/datadoghq/stickerlandia/stickeraward/StickerResourceTest.java
+++ b/sticker-award/src/test/java/com/datadoghq/stickerlandia/stickeraward/StickerResourceTest.java
@@ -1,0 +1,161 @@
+package com.datadoghq.stickerlandia.stickeraward;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+
+import com.datadoghq.stickerlandia.stickeraward.sticker.dto.CreateStickerRequest;
+import com.datadoghq.stickerlandia.stickeraward.sticker.entity.Sticker;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class StickerResourceTest {
+
+    private static final String EXISTING_STICKER_ID = "test-sticker-001";
+    private static final String NON_EXISTING_STICKER_ID = "non-existing-sticker";
+
+    @Inject EntityManager em;
+
+    @BeforeEach
+    @Transactional
+    void setupTestData() {
+        // Create a test sticker
+        Sticker sticker = Sticker.findById(EXISTING_STICKER_ID);
+        if (sticker == null) {
+            sticker =
+                    new Sticker(
+                            EXISTING_STICKER_ID,
+                            "Test Sticker",
+                            "For testing purposes",
+                            "http://example.com/test.png",
+                            100);
+            sticker.persist();
+        }
+    }
+
+    @Test
+    void testGetAllStickers() {
+        given().when()
+                .get("/api/stickers/v1")
+                .then()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body("stickers.size()", is(notNullValue()));
+    }
+
+    @Test
+    void testCreateSticker() {
+        CreateStickerRequest request = new CreateStickerRequest();
+        request.setStickerName("New Test Sticker");
+        request.setStickerDescription("A new sticker for testing");
+        request.setStickerQuantityRemaining(50);
+
+        given().contentType(ContentType.JSON)
+                .body(request)
+                .when()
+                .post("/api/stickers/v1")
+                .then()
+                .statusCode(201)
+                .contentType(ContentType.JSON)
+                .body("stickerId", notNullValue())
+                .body("stickerName", is("New Test Sticker"));
+    }
+
+    @Test
+    void testGetExistingStickerMetadata() {
+        given().when()
+                .get("/api/stickers/v1/{stickerId}", EXISTING_STICKER_ID)
+                .then()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body("stickerId", is(EXISTING_STICKER_ID))
+                .body("stickerName", notNullValue());
+    }
+
+    @Test
+    void testGetNonExistingStickerMetadataReturns404() {
+        given().when()
+                .get("/api/stickers/v1/{stickerId}", NON_EXISTING_STICKER_ID)
+                .then()
+                .statusCode(404)
+                .contentType("application/problem+json")
+                .body("status", is(404))
+                .body("title", is("Not Found"))
+                .body("detail", is("Sticker with ID " + NON_EXISTING_STICKER_ID + " not found"));
+    }
+
+    @Test
+    void testUpdateNonExistingStickerReturns404() {
+        CreateStickerRequest updateRequest = new CreateStickerRequest();
+        updateRequest.setStickerName("Updated Name");
+
+        given().contentType(ContentType.JSON)
+                .body(updateRequest)
+                .when()
+                .put("/api/stickers/v1/{stickerId}", NON_EXISTING_STICKER_ID)
+                .then()
+                .statusCode(404)
+                .contentType("application/problem+json")
+                .body("status", is(404))
+                .body("title", is("Not Found"))
+                .body("detail", is("Sticker with ID " + NON_EXISTING_STICKER_ID + " not found"));
+    }
+
+    @Test
+    void testDeleteNonExistingStickerReturns404() {
+        given().when()
+                .delete("/api/stickers/v1/{stickerId}", NON_EXISTING_STICKER_ID)
+                .then()
+                .statusCode(404)
+                .contentType("application/problem+json")
+                .body("status", is(404))
+                .body("title", is("Not Found"))
+                .body("detail", is("Sticker with ID " + NON_EXISTING_STICKER_ID + " not found"));
+    }
+
+    @Test
+    void testGetImageForNonExistingStickerReturns404() {
+        given().when()
+                .get("/api/stickers/v1/{stickerId}/image", NON_EXISTING_STICKER_ID)
+                .then()
+                .statusCode(404)
+                .contentType("application/problem+json")
+                .body("status", is(404))
+                .body("title", is("Not Found"))
+                .body("detail", is("Sticker with ID " + NON_EXISTING_STICKER_ID + " not found"));
+    }
+
+    @Test
+    void testGetImageForStickerWithoutImageReturns404() {
+        given().when()
+                .get("/api/stickers/v1/{stickerId}/image", EXISTING_STICKER_ID)
+                .then()
+                .statusCode(404)
+                .contentType("application/problem+json")
+                .body("status", is(404))
+                .body("title", is("Not Found"))
+                .body("detail", is("No image found for sticker " + EXISTING_STICKER_ID));
+    }
+
+    @Test
+    void testUploadImageForNonExistingStickerReturns404() {
+        byte[] fakeImageData = "fake-png-data".getBytes();
+
+        given().contentType("image/png")
+                .body(fakeImageData)
+                .when()
+                .post("/api/stickers/v1/{stickerId}/image", NON_EXISTING_STICKER_ID)
+                .then()
+                .statusCode(404)
+                .contentType("application/problem+json")
+                .body("status", is(404))
+                .body("title", is("Not Found"))
+                .body("detail", is("Sticker with ID " + NON_EXISTING_STICKER_ID + " not found"));
+    }
+}

--- a/sticker-award/src/test/java/com/datadoghq/stickerlandia/stickeraward/common/exception/ProblemDetailsExceptionMapperTest.java
+++ b/sticker-award/src/test/java/com/datadoghq/stickerlandia/stickeraward/common/exception/ProblemDetailsExceptionMapperTest.java
@@ -1,0 +1,103 @@
+package com.datadoghq.stickerlandia.stickeraward.common.exception;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.datadoghq.stickerlandia.stickeraward.common.dto.ProblemDetails;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.ForbiddenException;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ProblemDetailsExceptionMapperTest {
+
+    private ProblemDetailsExceptionMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        mapper = new ProblemDetailsExceptionMapper();
+    }
+
+    @Test
+    void testMapBadRequestException() {
+        WebApplicationException exception = new BadRequestException("Invalid input data");
+
+        Response response = mapper.toResponse(exception);
+
+        assertEquals(400, response.getStatus());
+        assertEquals("application/problem+json", response.getHeaders().getFirst("Content-Type"));
+
+        ProblemDetails problemDetails = (ProblemDetails) response.getEntity();
+        assertNotNull(problemDetails);
+        assertEquals(400, problemDetails.getStatus());
+        assertEquals("Bad Request", problemDetails.getTitle());
+        assertEquals("Invalid input data", problemDetails.getDetail());
+    }
+
+    @Test
+    void testMapNotFoundException() {
+        WebApplicationException exception = new NotFoundException("Resource not found");
+
+        Response response = mapper.toResponse(exception);
+
+        assertEquals(404, response.getStatus());
+        assertEquals("application/problem+json", response.getHeaders().getFirst("Content-Type"));
+
+        ProblemDetails problemDetails = (ProblemDetails) response.getEntity();
+        assertNotNull(problemDetails);
+        assertEquals(404, problemDetails.getStatus());
+        assertEquals("Not Found", problemDetails.getTitle());
+        assertEquals("Resource not found", problemDetails.getDetail());
+    }
+
+    @Test
+    void testMapForbiddenException() {
+        WebApplicationException exception = new ForbiddenException("Access denied");
+
+        Response response = mapper.toResponse(exception);
+
+        assertEquals(403, response.getStatus());
+        assertEquals("application/problem+json", response.getHeaders().getFirst("Content-Type"));
+
+        ProblemDetails problemDetails = (ProblemDetails) response.getEntity();
+        assertNotNull(problemDetails);
+        assertEquals(403, problemDetails.getStatus());
+        assertEquals("Forbidden", problemDetails.getTitle());
+        assertEquals("Access denied", problemDetails.getDetail());
+    }
+
+    @Test
+    void testMapGenericWebApplicationException() {
+        WebApplicationException exception = new WebApplicationException("Server error", 500);
+
+        Response response = mapper.toResponse(exception);
+
+        assertEquals(500, response.getStatus());
+        assertEquals("application/problem+json", response.getHeaders().getFirst("Content-Type"));
+
+        ProblemDetails problemDetails = (ProblemDetails) response.getEntity();
+        assertNotNull(problemDetails);
+        assertEquals(500, problemDetails.getStatus());
+        assertEquals("Internal Server Error", problemDetails.getTitle());
+        assertEquals("Server error", problemDetails.getDetail());
+    }
+
+    @Test
+    void testMapUnknownStatusCode() {
+        WebApplicationException exception = new WebApplicationException("Unknown error", 418);
+
+        Response response = mapper.toResponse(exception);
+
+        assertEquals(418, response.getStatus());
+        assertEquals("application/problem+json", response.getHeaders().getFirst("Content-Type"));
+
+        ProblemDetails problemDetails = (ProblemDetails) response.getEntity();
+        assertNotNull(problemDetails);
+        assertEquals(418, problemDetails.getStatus());
+        assertEquals("Error", problemDetails.getTitle());
+        assertEquals("Unknown error", problemDetails.getDetail());
+    }
+}


### PR DESCRIPTION
Fixes #16 . 
This brings it in sync with both the spec, and the error structure in user-service, implementing [RFC7807 problem details](https://datatracker.ietf.org/doc/html/rfc7807).