### PR TITLE
feat: add user stories

### DIFF
--- a/docs/stories/README.md
+++ b/docs/stories/README.md
@@ -1,0 +1,13 @@
+# Stickerlandia User Stories
+
+This document outlines the user stories for Stickerlandia, sorted by likely implementation order.
+
+## User Stories by Implementation Order
+
+| Feature | Description |
+|---------|-------------|
+| Sign in with preferred identity provider and access profile information | Core authentication system enabling user registration and login with identity providers. Includes welcome sticker and onboarding. |
+| Collect stickers through various activities | Core sticker collection mechanics including certification rewards, scheduled drops, and limited edition stickers with serial numbers and cryptographic signing. *Requires authentication.* |
+| Share collection publicly | Public profiles, social media integration, and collection showcasing features. *Requires existing sticker collection.* |
+| Deploy Stickerlandia to different platforms | Infrastructure and deployment capabilities for AWS serverless and Kubernetes with monitoring. |
+| Print digital stickers at events | Event-based physical sticker printing with QR codes, NFC badges, and print history tracking. *Requires sticker collection and event coordination.* |

--- a/docs/stories/auth_and_profile_management.gherkin
+++ b/docs/stories/auth_and_profile_management.gherkin
@@ -1,0 +1,20 @@
+Feature: User Authentication
+  As a Datadog user
+  I want to sign in with my preferred identity provider
+  So that I can start collecting stickers
+
+  Scenario: First-time user registration
+    Given I am not registered in Stickerlandia
+    When I click "Sign In" and select my identity provider
+    And I authorize Stickerlandia to access my basic profile
+    Then I should be registered with a new profile
+    And I should receive a welcome sticker automatically
+    And I should see an onboarding tutorial
+
+  Scenario: Returning user login
+    Given I have an existing Stickerlandia account
+    When I sign in with my registered identity provider
+    Then I should be redirected to my profile dashboard
+    And I should see my current sticker collection
+    And I should see any unclaimed rewards
+

--- a/docs/stories/non_functional_requirements.gherkin
+++ b/docs/stories/non_functional_requirements.gherkin
@@ -1,0 +1,18 @@
+Feature: Multi-platform Deployment
+  As a developer
+  I want to deploy Stickerlandia to different platforms
+  So that I can demonstrate platform flexibility
+
+  Scenario: AWS Serverless deployment
+    Given the application is packaged for serverless
+    When I run the deployment script for AWS
+    Then all microservices should deploy as Lambda functions
+    And the frontend should deploy to CloudFront
+    And all services should be monitored in Datadog
+
+  Scenario: Kubernetes deployment
+    Given the application is containerized
+    When I deploy to a K8s cluster
+    Then all microservices should run as separate pods
+    And services should communicate via service mesh
+    And Datadog agents should collect all metrics

--- a/docs/stories/physical_printing.gherkin
+++ b/docs/stories/physical_printing.gherkin
@@ -1,0 +1,27 @@
+Feature: Sticker Printing at Events
+  As an event attendee
+  I want to print my digital stickers
+  So that I can have physical versions
+
+  Scenario: Event check-in with QR code
+    Given I am at a Datadog event with printing stations
+    And I have stickers in my collection
+    When I generate my personal QR code in the app
+    And scan it at the printing station
+    Then the station should display my sticker collection
+    And I should be able to select up to 10 stickers to print
+    And the printer should produce physical stickers
+
+  Scenario: Print history tracking
+    Given I have printed stickers at previous events
+    When I view my print history
+    Then I should see which stickers were printed
+    And I should see the event location and date
+    And I should see my remaining print credits for current event
+
+  Scenario: Event sticker collection with NFC badge
+    Given I am at a Datadog event with printing stations
+    And I have signed in to the event with my QR code
+    When I scan my NFC badge at the printing station
+    Then the station should grant me an event-specific sticker
+

--- a/docs/stories/social_features.gherkin
+++ b/docs/stories/social_features.gherkin
@@ -1,0 +1,22 @@
+Feature: Social Sharing
+  As a sticker collector
+  I want to share my collection publicly
+  So that I can showcase my achievements
+
+  Scenario: Public profile creation
+    Given I have collected at least 5 stickers
+    When I enable my public profile
+    And I customize my display name and bio
+    And I customize my highlighted stickers
+    Then my profile should be accessible at /users/{username}
+    And it should display my sticker collection
+    And it should show my collection statistics
+
+  Scenario: Social media integration
+    Given I have a rare sticker in my collection
+    When I click "Share" on the sticker
+    And I select Twitter/LinkedIn/etc
+    Then a pre-formatted post should be created
+    And it should include a preview image of the sticker
+    And it should link back to my public profile
+

--- a/docs/stories/sticker_collection.gherkin
+++ b/docs/stories/sticker_collection.gherkin
@@ -1,0 +1,30 @@
+Feature: Sticker Collection
+  As a registered user
+  I want to collect stickers through various activities
+  So that I can build my collection and show achievements
+
+  Scenario: Claiming certification reward
+    Given I have completed a Datadog certification
+    And the certification is verified in the training platform
+    When I navigate to the "Claim Rewards" section
+    Then I should see my unclaimed certification sticker
+    And I should be able to claim it with one click
+    And the sticker should appear in my collection with a "New" badge
+
+  Scenario: Scheduled sticker drop
+    Given a scheduled drop is occurring
+    And I am logged in during the drop window
+    When I visit the drops page
+    Then I should see the available sticker
+    And I should be able to claim it if I haven't already
+    And I should see a countdown to the next drop
+
+  Scenario: Limited supply sticker
+    Given a limited edition sticker with 1000 total supply
+    And 950 have already been claimed
+    When I view the sticker details
+    Then I should see "50 remaining out of 1000"
+    And I should see a real-time counter updating
+    And once claimed, it should show my serial number (e.g., "#951 of 1000")
+	And once claimed, my serial number should be baked into any images of the sticker I see, and the sticker images should be crytographically signed
+


### PR DESCRIPTION
From our internal user stories doc, so we can reference them when we start creating work items.