### PR TITLE
feat: hot reloading for web-frontend

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -61,24 +61,53 @@ services:
       - go-mod-cache:/go/pkg/mod     # Persist Go module cache
     command: ["air", "-c", ".air.toml"]
 
-  user-management:
-    build:
-      context: ./user-management
-      dockerfile: Dockerfile.dev
-    volumes:
-      # Mount source code for live reload
-      - ./user-management:/app:cached
-      # Mount NuGet cache to speed up builds
-      - nuget-cache:/root/.nuget/packages
-    environment:
-      # Configure driven adapters
-      - DRIVEN=AGNOSTIC
-      # Development environment
-      - ASPNETCORE_ENVIRONMENT=Development
-      - ASPNETCORE_URLS=http://+:8080
+  #
+  # Hot reload for user-management doesn't work yet, so let's
+  # comment this out so the user-management without reloading
+  # from the main compose file gets used.
+  # 
+  # user-management:
+  #   build:
+  #     context: ./user-management
+  #     dockerfile: Dockerfile.dev
+  #   volumes:
+  #     # Mount source code for live reload
+  #     - ./user-management:/app:cached
+  #     # Mount NuGet cache to speed up builds
+  #     - nuget-cache:/root/.nuget/packages
+  #   environment:
+  #     # Configure driven adapters
+  #     - DRIVEN=AGNOSTIC
+  #     # Development environment
+  #     - ASPNETCORE_ENVIRONMENT=Development
+  #     - ASPNETCORE_URLS=http://+:8080
 
+  # web-frontend:
+  #   # platform: linux/amd64  # Force x86-64 to avoid ARM64 rollup issues
+  #   build:
+  #     context: ./web-frontend
+  #     dockerfile: Dockerfile.dev
+  #   volumes:
+  #     # Mount source code for live reload
+  #     - ./web-frontend:/app:cached
+  #     # Mount node modules over the top, so that modules from the host don't get used
+  #     # this is necessary for platform-specific modules.
+  #     - web-frontend-node-modules-cache:/app/node_modules:cached
+  #     # Mount npm cache to speed up builds
+  #     - npm-cache:/root/.npm
+  #   environment:
+  #     # Vite configuration for development
+  #     - VITE_API_BASE_URL=http://localhost:8080
+  #     - NODE_ENV=
+  #   labels:
+  #     - "traefik.enable=true"
+  #     - "traefik.http.routers.web-frontend.rule=PathPrefix(`/`)"
+  #     - "traefik.http.routers.web-frontend.priority=1"
+  #     - "traefik.http.services.web-frontend.loadbalancer.server.port=8080"
 
 volumes:
   maven-cache:
   go-mod-cache:
   nuget-cache:
+  npm-cache:
+  web-frontend-node-modules-cache:

--- a/web-frontend/Dockerfile.dev
+++ b/web-frontend/Dockerfile.dev
@@ -1,0 +1,17 @@
+# Development Dockerfile for React Frontend
+# Provides hot-reload via Vite development server
+# Use docker-compose.dev.yml in the stickerlandia root to use this!
+
+FROM node:22
+
+ENV NODE_ENV=development
+
+# The working directory mirrors the bind-mount from the host
+WORKDIR /app
+
+# Expose Vite dev server port
+EXPOSE 5173
+EXPOSE 8080
+
+# Start Vite dev server with host binding for Docker
+CMD ["./scripts/dev-container-start.sh"]

--- a/web-frontend/scripts/dev-container-start.sh
+++ b/web-frontend/scripts/dev-container-start.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+# Restore packages - in dev mode, we have to do this at runtime,
+# so that we can mount an empty node_modules over the top of our
+# source mount from the host. If we _don't_ do this, we'll have issues
+# trying to re-use platform specific modules from the source.
+npm install
+
+# Start it!
+npm run dev -- --host 0.0.0.0 --port 8080

--- a/web-frontend/vite.config.js
+++ b/web-frontend/vite.config.js
@@ -7,13 +7,22 @@ export default defineConfig({
  base: "/",
  plugins: [react()],
  preview: {
-  port: 8080,
+  port: 5173,
   strictPort: true,
  },
  server: {
-  port: 8080,
+  port: 5173,
   strictPort: true,
   host: true,
-  origin: "http://0.0.0.0:8080",
+  origin: "http://0.0.0.0:5173",
+ },
+ build: {
+  rollupOptions: {
+   // Force JS-only rollup to avoid native binary issues
+   external: [],
+   output: {
+    manualChunks: undefined,
+   },
+  },
  },
 });


### PR DESCRIPTION
Does what it says on the tin, wrapping web-frontend in a minimal container to let vite dev mode run within docker-compose.dev.yml, so it integrates with the whole service suite but still supports hot reloading.
