### PR TITLE
chore(web-frontend): fix RUM env injection

### DIFF
--- a/web-frontend/.env
+++ b/web-frontend/.env
@@ -1,3 +1,12 @@
 # Environment variables for vite-envs
 # This file is required by vite-envs plugin even if empty
 # Actual environment variables are injected at runtime by vite-envs
+
+# Datadog RUM environment variables
+# Values are set at runtime by Docker Compose
+DD_RUM_APPLICATION_ID=
+DD_RUM_CLIENT_TOKEN=
+DD_SITE=
+DD_ENV=
+DD_VERSION=
+DD_SERVICE=

--- a/web-frontend/src/vite-env.d.ts
+++ b/web-frontend/src/vite-env.d.ts
@@ -9,6 +9,12 @@ type ImportMetaEnv = {
   MODE: string
   DEV: boolean
   PROD: boolean
+  DD_RUM_APPLICATION_ID: string
+  DD_RUM_CLIENT_TOKEN: string
+  DD_SITE: string
+  DD_ENV: string
+  DD_VERSION: string
+  DD_SERVICE: string
   // @user-defined-start
   /*
    *  You can use this section to explicitly extend the type definition of `import.meta.env`


### PR DESCRIPTION
This wasn't working properly; the script that is doing the dynamic injection of RUM properties at startup into the frontend bundle needs to be told beforehand which properties to inject. 