### PR TITLE
feat: add basic support for admin and user roles

### DIFF
--- a/user-management/src/Stickerlandia.UserManagement.Api/Program.cs
+++ b/user-management/src/Stickerlandia.UserManagement.Api/Program.cs
@@ -106,7 +106,8 @@ v1ApiEndpoints.MapGet("{userId}/details", GetUserDetails.HandleAsync)
     {
         policyBuilder.AuthenticationSchemes = new List<string>(1)
             { OpenIddictValidationAspNetCoreDefaults.AuthenticationScheme };
-        policyBuilder.RequireAuthenticatedUser();
+        policyBuilder.RequireAuthenticatedUser()
+            .RequireRole(UserTypes.Admin, UserTypes.User);
     })
     .WithDescription("Get the current authenticated users details")
     .Produces<ApiResponse<UserAccountDto>>(200)
@@ -118,7 +119,8 @@ v1ApiEndpoints.MapPut("{userId}/details", UpdateUserDetailsEndpoint.HandleAsync)
     {
         policyBuilder.AuthenticationSchemes = new List<string>(1)
             { OpenIddictValidationAspNetCoreDefaults.AuthenticationScheme };
-        policyBuilder.RequireAuthenticatedUser();
+        policyBuilder.RequireAuthenticatedUser()
+            .RequireRole(UserTypes.Admin, UserTypes.User);
     })
     .WithDescription("Update the user details")
     .Produces<ApiResponse<string>>(200)

--- a/user-management/src/Stickerlandia.UserManagement.Core/PostgresUserAccount.cs
+++ b/user-management/src/Stickerlandia.UserManagement.Core/PostgresUserAccount.cs
@@ -17,6 +17,19 @@ public class PostgresUserAccount : IdentityUser
 
     internal bool Changed { get; private set; }
 
+    public static PostgresUserAccount New(string emailAddress, string firstName, string lastName)
+    {
+        var userAccount = new PostgresUserAccount();
+        userAccount.UserName = emailAddress;
+        userAccount.Email = emailAddress;
+        userAccount.EmailConfirmed = true;
+        userAccount.FirstName = firstName;
+        userAccount.LastName = lastName;
+        userAccount.DateCreated = DateTime.UtcNow;
+
+        return userAccount;
+    }
+
     public void UpdateUserDetails(string newFirstName, string newLastName)
     {
         if (!string.IsNullOrEmpty(newFirstName) && newFirstName != FirstName)

--- a/user-management/src/Stickerlandia.UserManagement.Core/UserTypes.cs
+++ b/user-management/src/Stickerlandia.UserManagement.Core/UserTypes.cs
@@ -1,0 +1,11 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025 Datadog, Inc.
+
+namespace Stickerlandia.UserManagement.Core;
+
+public static class UserTypes
+{
+    public const string User = "user";
+    public const string Admin = "admin";
+}


### PR DESCRIPTION
fixes #64 

Add basic support for identity roles.
- Creates a 'user' and 'admin' role as part of application startup
- The default users get assigned to the 'user' and 'admin' roles respectively
- Add role policies to GET and PUT endpoints, to ensure the user must have either an admin or user role

This PR the minimum to add supports for roles, and doesn't actually restrict any permissions based on the roles.