### PR TITLE
chore: make devcontainers use prebuilt image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-	"name": "Hot-reloading dev env",
+	"name": "Prebuilt demo environment",
 
 	"dockerComposeFile": [
 		"docker-compose.yml"

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -20,7 +20,7 @@ git config --global --add safe.directory /workspace
 
 # Build containers
 echo "Starting stickerlandia"
-make compose-up
+make compose-prebuilt-up
 
 echo "✅ Development environment setup complete!"
 echo ""

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,10 @@ help:
 	@echo "===================================="
 	@echo ""
 	@echo "Main targets:"
-	@echo "  compose-up      - Start all services in production mode"
-	@echo "  compose-dev-up  - Start all services in development mode (with hot reloading)"
-	@echo "  compose-down    - Stop and remove all containers and storage volumes"
+	@echo "  compose-up          - Start all services in production mode"
+	@echo "  compose-dev-up      - Start all services in development mode (with hot reloading)"
+	@echo "  compose-prebuilt-up - Start all services using prebuilt images from GHCR"
+	@echo "  compose-down        - Stop and remove all containers and storage volumes"
 	@echo ""
 	@echo "Other targets:"
 	@echo "  time-startup    - Time the entire startup process"
@@ -97,7 +98,11 @@ compose-up: .env
 
 compose-dev-up: .env
 	docker compose --profile monitoring -f docker-compose.yml -f docker-compose.dev.yml build && docker compose --profile monitoring -f docker-compose.yml -f docker-compose.dev.yml up -d
-	
+
+compose-prebuilt-up: .env
+	docker compose --profile monitoring -f docker-compose.yml -f docker-compose.prebuilt.yml up -d
+	docker logs user-management
+
 compose-up-ci: .env
 	docker compose build && docker compose up -d
 	docker logs user-management

--- a/docker-compose.prebuilt.yml
+++ b/docker-compose.prebuilt.yml
@@ -1,0 +1,34 @@
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2025-Present Datadog, Inc.
+
+# Docker Compose override for using prebuilt images from GHCR
+# Usage: docker-compose -f docker-compose.yml -f docker-compose.prebuilt.yml up
+services:
+  sticker-catalogue:
+    image: ghcr.io/datadog/stickerlandia/sticker-catalogue-service:latest
+    build: {}
+
+  sticker-award:
+    image: ghcr.io/datadog/stickerlandia/sticker-award-service:latest
+    build: {}
+
+  user-management:
+    image: ghcr.io/datadog/stickerlandia/user-management-service:latest
+    build: {}
+
+  user-management-worker:
+    image: ghcr.io/datadog/stickerlandia/user-management-worker:latest
+    build: {}
+
+  user-management-db-migrations:
+    image: ghcr.io/datadog/stickerlandia/user-management-migration:latest
+    build: {}
+
+  web-backend:
+    image: ghcr.io/datadog/stickerlandia/web-backend-service:latest
+    build: {}
+
+  web-frontend:
+    image: ghcr.io/datadog/stickerlandia/web-frontend:latest
+    build: {}


### PR DESCRIPTION
The idea here is to make the regular devcontainer experience very fast to get the app going so that launching it in codespaces provides a great first experience.