### PR TITLE
chore: Dont autoforward ports in devcontainers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,12 +12,6 @@
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {}
 	},
 
-	"forwardPorts": [
-		8080,
-		8081, 
-		8082
-	],
-
 	"portsAttributes": {
 	  "8080": {
 	    "label": "stickerlandia"


### PR DESCRIPTION
.... this appears to cause issues with ports that are not open when the github codespace launches, with the endpoints simply returning 502 until the forward is deleted and recreated.

It appears that codespaces will automatically re-forward ports when they open, so this should be a better option. 