### PR TITLE
chore(sticker-award): bump golang to 1.25

### DIFF
--- a/sticker-award/.air.toml
+++ b/sticker-award/.air.toml
@@ -4,7 +4,7 @@ tmp_dir = "tmp"
 
 [build]
   # Build command with disabled optimisations for easier debugging
-  cmd = "go build -gcflags=all=-N ./cmd/server"
+  cmd = "go build -buildvcs=false -gcflags=all=-N ./cmd/server"
   bin = "server"
   include_ext = ["go", "tpl", "tmpl", "html"]
   exclude_dir = ["tmp", "vendor", ".git"]

--- a/sticker-award/Dockerfile
+++ b/sticker-award/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.23-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 ARG GIT_COMMIT_SHA
 ARG GIT_REPOSITORY_URL

--- a/sticker-award/Dockerfile.dev
+++ b/sticker-award/Dockerfile.dev
@@ -2,7 +2,7 @@
 # Provides hot-reload via Air and debugging via Delve
 # Use docker-compose.dev.yml in the stickerlandia root to use this!
 
-FROM golang:1.24-alpine
+FROM golang:1.25-alpine
 
 ARG GIT_COMMIT_SHA
 ARG GIT_REPOSITORY_URL
@@ -11,7 +11,7 @@ ENV DD_GIT_COMMIT_SHA=${GIT_COMMIT_SHA}
 
 # Install OS dependencies and dev tools
 RUN apk add --no-cache git bash curl tzdata \
-    && go install github.com/air-verse/air@latest \
+    && go install github.com/air-verse/air@v1.63.1 \
     && go install github.com/go-delve/delve/cmd/dlv@latest
 
 # The working directory mirrors the bind-mount from the host

--- a/sticker-award/go.mod
+++ b/sticker-award/go.mod
@@ -1,8 +1,8 @@
 module github.com/datadog/stickerlandia/sticker-award
 
-go 1.23.0
+go 1.25.0
 
-toolchain go1.24.5
+toolchain go1.25
 
 require (
 	github.com/DataDog/dd-trace-go/contrib/IBM/sarama/v2 v2.2.2


### PR DESCRIPTION
Had an issue with floating deps in the dev image; used it as an oppy to roll golang forward.