### PR TITLE
Update traefik to 3.6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@
 
 services:
   traefik:
-    image: traefik:v3.0
+    image: traefik:v3.6
     container_name: traefik
     ports:
       - "8080:80"     # App traffic


### PR DESCRIPTION
Traefik 3.6 introduced support for Docker 4.52+