### PR TITLE
fix: remove CORS configuration

### DIFF
--- a/user-management/src/Stickerlandia.UserManagement.Api/Program.cs
+++ b/user-management/src/Stickerlandia.UserManagement.Api/Program.cs
@@ -66,14 +66,6 @@ builder.Services.AddResponseCompression(options => { options.EnableForHttps = tr
 
 builder.Services.AddControllersWithViews();
 builder.Services.AddRazorPages();
-builder.Services.AddCors(options =>
-{
-    options.AddPolicy("AllowAll",
-        builder => builder
-            .AllowAnyOrigin()
-            .AllowAnyMethod()
-            .AllowAnyHeader());
-});
 
 var app = builder.Build();
 
@@ -114,8 +106,6 @@ if (app.Environment.IsDevelopment())
         options.SwaggerEndpoint(url, name);
     });
 }
-
-app.UseCors("AllowAll");
 
 app.UseRouting();
 app.UseStaticFiles();


### PR DESCRIPTION
Resolves #63 

The application runs behind a single URL (frontend and backend) so CORS configuration is not required.

Manual test environments

* [x] Local docker compose
* [x] Codespaces
* [x] AWS