### PR TITLE
chore: clean up mise aws deploy tasks

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -143,14 +143,30 @@ depends = ["env:setup"]
 run = "./scripts/test-services.sh --max-retries 5 --retry-delay 10"
 
 # =============================================================================
-# aws: AWS tasks
+# aws: AWS deployment tasks
+#
+# Deployment modes are controlled via the DEPLOY_MODE environment variable:
+#   - local:   Build containers from local Dockerfiles (DEPLOY_MODE=local)
+#   - release: Pull prebuilt images from GHCR tagged "latest" (DEPLOY_MODE=release)
+#   - (unset): Falls back to COMMIT_SHA env var, or "latest" if not set
+#
+# DEPLOY_MODE is NOT stored in .env, so it propagates naturally through
+# subprocess calls. CDK's SharedProps reads DEPLOY_MODE and sets the
+# appropriate image tag. Services can define their own aws:deploy:local
+# and aws:deploy:release tasks that set DEPLOY_MODE and delegate to aws:deploy.
+#
+# To deploy a specific tagged version from the registry (e.g., a CI-built
+# image), set COMMIT_SHA to the desired tag and run aws:deploy directly
+# without setting DEPLOY_MODE. For example:
+#   COMMIT_SHA=abc123 npx cdk deploy (from infra/aws directory)
 # =============================================================================
 
 [tasks."aws:deploy:local"]
 description = "Deploy to AWS (build containers locally)"
 depends = ["env:setup"]
+env = { DEPLOY_MODE = "local" }
 run = """
-echo "=== Deploying Stickerlandia to AWS: $ENV (COMMIT_SHA=$COMMIT_SHA) ==="
+echo "=== Deploying Stickerlandia to AWS: $ENV (DEPLOY_MODE=$DEPLOY_MODE) ==="
 mise run //shared:aws:deploy
 mise run //user-management:aws:deploy
 mise run //sticker-award:aws:deploy
@@ -163,9 +179,9 @@ echo "=== Deployment complete! ==="
 [tasks."aws:deploy:release"]
 description = "Deploy to AWS using prebuilt GHCR images"
 depends = ["env:setup"]
-env = { COMMIT_SHA = "latest" }
+env = { DEPLOY_MODE = "release" }
 run = """
-echo "=== Deploying Stickerlandia to AWS: $ENV (COMMIT_SHA=$COMMIT_SHA) ==="
+echo "=== Deploying Stickerlandia to AWS: $ENV (DEPLOY_MODE=$DEPLOY_MODE) ==="
 mise run //shared:aws:deploy
 mise run //user-management:aws:deploy
 mise run //sticker-award:aws:deploy

--- a/shared/lib/shared-constructs/lib/shared-props.ts
+++ b/shared/lib/shared-constructs/lib/shared-props.ts
@@ -43,7 +43,15 @@ export class SharedProps {
     enableDatadog: boolean = true
   ) {
     const environment = process.env.ENV || "dev";
-    const version = process.env.COMMIT_SHA || "latest";
+    const deployMode = process.env.DEPLOY_MODE;
+    let version: string;
+    if (deployMode === "local") {
+      version = "LOCAL";
+    } else if (deployMode === "release") {
+      version = "latest";
+    } else {
+      version = process.env.COMMIT_SHA || "latest";
+    }
     const commitSha = process.env.COMMIT_SHA_FULL || "";
 
     this.datadog = {

--- a/shared/mise.toml
+++ b/shared/mise.toml
@@ -20,6 +20,18 @@ dir = "infra/aws"
 depends = ["lib:install", "infra:install"]
 run = "npx cdk deploy --require-approval never"
 
+[tasks."aws:deploy:local"]
+description = "Deploy shared infrastructure (local mode)"
+depends = ["//:env:setup"]
+env = { DEPLOY_MODE = "local" }
+run = "mise run aws:deploy"
+
+[tasks."aws:deploy:release"]
+description = "Deploy shared infrastructure (release mode)"
+depends = ["//:env:setup"]
+env = { DEPLOY_MODE = "release" }
+run = "mise run aws:deploy"
+
 [tasks."aws:down"]
 description = "Destroy shared infrastructure on AWS"
 dir = "infra/aws"

--- a/sticker-award/mise.toml
+++ b/sticker-award/mise.toml
@@ -31,6 +31,18 @@ dir = "infra/aws"
 depends = ["infra:install", "//shared:aws:deploy"]
 run = "npx cdk deploy --require-approval never"
 
+[tasks."aws:deploy:local"]
+description = "Deploy to AWS (build container locally)"
+depends = ["//:env:setup", "//shared:aws:deploy:local", "//user-management:aws:deploy:local"]
+env = { DEPLOY_MODE = "local" }
+run = "mise run aws:deploy"
+
+[tasks."aws:deploy:release"]
+description = "Deploy to AWS using prebuilt GHCR images"
+depends = ["//:env:setup", "//shared:aws:deploy:release", "//user-management:aws:deploy:release"]
+env = { DEPLOY_MODE = "release" }
+run = "mise run aws:deploy"
+
 [tasks."aws:down"]
 description = "Destroy AWS stack"
 dir = "infra/aws"

--- a/sticker-catalogue/mise.toml
+++ b/sticker-catalogue/mise.toml
@@ -31,6 +31,18 @@ dir = "infra/aws"
 depends = ["infra:install", "//shared:aws:deploy"]
 run = "npx cdk deploy --require-approval never"
 
+[tasks."aws:deploy:local"]
+description = "Deploy to AWS (build container locally)"
+depends = ["//:env:setup", "//shared:aws:deploy:local", "//user-management:aws:deploy:local"]
+env = { DEPLOY_MODE = "local" }
+run = "mise run aws:deploy"
+
+[tasks."aws:deploy:release"]
+description = "Deploy to AWS using prebuilt GHCR images"
+depends = ["//:env:setup", "//shared:aws:deploy:release", "//user-management:aws:deploy:release"]
+env = { DEPLOY_MODE = "release" }
+run = "mise run aws:deploy"
+
 [tasks."aws:down"]
 description = "Destroy AWS stack"
 dir = "infra/aws"

--- a/user-management/mise.toml
+++ b/user-management/mise.toml
@@ -35,6 +35,18 @@ dir = "infra/aws"
 depends = ["infra:install", "//shared:aws:deploy"]
 run = "npx cdk deploy --require-approval never"
 
+[tasks."aws:deploy:local"]
+description = "Deploy to AWS (build container locally)"
+depends = ["//:env:setup", "//shared:aws:deploy:local"]
+env = { DEPLOY_MODE = "local" }
+run = "mise run aws:deploy"
+
+[tasks."aws:deploy:release"]
+description = "Deploy to AWS using prebuilt GHCR images"
+depends = ["//:env:setup", "//shared:aws:deploy:release"]
+env = { DEPLOY_MODE = "release" }
+run = "mise run aws:deploy"
+
 [tasks."aws:down"]
 description = "Destroy AWS stack"
 dir = "infra/aws"

--- a/web-backend/mise.toml
+++ b/web-backend/mise.toml
@@ -31,6 +31,18 @@ dir = "infra/aws"
 depends = ["infra:install", "//shared:aws:deploy"]
 run = "npx cdk deploy --require-approval never"
 
+[tasks."aws:deploy:local"]
+description = "Deploy to AWS (build container locally)"
+depends = ["//:env:setup", "//shared:aws:deploy:local", "//user-management:aws:deploy:local"]
+env = { DEPLOY_MODE = "local" }
+run = "mise run aws:deploy"
+
+[tasks."aws:deploy:release"]
+description = "Deploy to AWS using prebuilt GHCR images"
+depends = ["//:env:setup", "//shared:aws:deploy:release", "//user-management:aws:deploy:release"]
+env = { DEPLOY_MODE = "release" }
+run = "mise run aws:deploy"
+
 [tasks."aws:down"]
 description = "Destroy AWS stack"
 dir = "infra/aws"

--- a/web-frontend/mise.toml
+++ b/web-frontend/mise.toml
@@ -38,6 +38,18 @@ dir = "infra/aws"
 depends = ["infra:install", "build:local", "//shared:aws:deploy"]
 run = "npx cdk deploy --require-approval never"
 
+[tasks."aws:deploy:local"]
+description = "Deploy frontend to AWS (local mode)"
+depends = ["//:env:setup", "//shared:aws:deploy:local", "//user-management:aws:deploy:local"]
+env = { DEPLOY_MODE = "local" }
+run = "mise run aws:deploy"
+
+[tasks."aws:deploy:release"]
+description = "Deploy frontend to AWS (release mode)"
+depends = ["//:env:setup", "//shared:aws:deploy:release", "//user-management:aws:deploy:release"]
+env = { DEPLOY_MODE = "release" }
+run = "mise run aws:deploy"
+
 [tasks."aws:down"]
 description = "Destroy AWS stack"
 dir = "infra/aws"


### PR DESCRIPTION
This PR makes `mise aws:deploy:local` work properly for individual services, not just at a stickerlandia-wide level. It also adds dependencies between the individual services and infrastructure (everything depends on infra, everything other than user-service depends on service-service), so that the requirements are automatically pulled in.

I've done this by introducing a distinction between DEPLOY_MODE and COMMIT_SHA. We use the former to choose to toggle on "local deploy" or "prebuilt release images" mode; if it is _unset_, we deploy using images tagged with the COMMIT_SHA.

If you set COMMIT_SHA to some actual hash and run a cdk deploy _directly_, you can deploy a particular version to AWS using the tagged GHCR images.
