### PR TITLE
chore: move mise tools to setup_localdev task

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -4,23 +4,24 @@ experimental_monorepo_root = true
 
 [settings]
 experimental = true
-auto_install = true
+auto_install = false
 
-[tools]
-# Used by CDK infrastructure and web-frontend/web-backend
-node = "22"
+# =============================================================================
+# setup: Local development environment setup
+# =============================================================================
 
-# Used by sticker-award
-go = "1.25"
-
-# Used by sticker-catalogue
-java = "temurin-21"
-
-# Used by sticker-catalogue
-maven = "3.9"
-
-# Used by user-management
-dotnet = "10"
+[tasks."setup_localdev"]
+description = "Install all development tools required for local development"
+run = """
+echo "Installing development tools..."
+mise use --global node@22
+mise use --global go@1.25
+mise use --global java@temurin-21
+mise use --global maven@3.9
+mise use --global dotnet@10
+echo "All development tools installed successfully!"
+echo "Tools can be activated by running 'mise activate' in your shell."
+"""
 
 # =============================================================================
 # env: Environment setup


### PR DESCRIPTION
Refactor mise.toml to remove global tool declarations and introduce a setup_localdev task for on-demand tool installation. This allows commands like `mise compose:deploy:release` to run without requiring all development tools to be installed on the host system.

## Changes
- Remove [tools] section with node, go, java, maven, and dotnet
- Set auto_install = false to prevent automatic tool installation
- Add setup_localdev task that installs all tools on-demand
- Tools are installed globally and available across all projects

Resolves #175

Generated with [Claude Code](https://claude.ai/code)