### PR TITLE
fix(aws): move CloudFront errorResponses to defaultBehavior only

### DIFF
--- a/shared/infra/aws/lib/network.ts
+++ b/shared/infra/aws/lib/network.ts
@@ -166,21 +166,22 @@ export class Network extends Construct {
         origin: S3BucketOrigin.withOriginAccessIdentity(webFrontendBucket, {
           originAccessIdentity: originIdentity,
         }),
+        // SPA routing: return index.html for any unmatched routes on the frontend
+        // S3 with OAI returns 403 for non-existent files, so we handle both 403 and 404
+        // This only applies to the default behavior (S3/frontend), not API routes
+        errorResponses: [
+          {
+            httpStatus: 403,
+            responseHttpStatus: 200,
+            responsePagePath: "/index.html",
+          },
+          {
+            httpStatus: 404,
+            responseHttpStatus: 200,
+            responsePagePath: "/index.html",
+          },
+        ],
       },
-      // SPA routing: return index.html for any unmatched routes
-      // S3 with OAI returns 403 for non-existent files, so we handle both 403 and 404
-      errorResponses: [
-        {
-          httpStatus: 403,
-          responseHttpStatus: 200,
-          responsePagePath: "/index.html",
-        },
-        {
-          httpStatus: 404,
-          responseHttpStatus: 200,
-          responsePagePath: "/index.html",
-        },
-      ],
     });
 
     const region = cdk.Stack.of(this).region;


### PR DESCRIPTION
Move the errorResponses configuration from the distribution level to only the defaultBehavior. This ensures that the SPA routing fallback (404 -> index.html) only applies to the S3 frontend origin, not to API routes (/api*, /auth*, /.well-known*).

Previously, the distribution-level errorResponses affected all behaviors including API routes, causing legitimate REST API 404s to be incorrectly rewritten to 200s with index.html content.

Fixes #173

---

Generated with [Claude Code](https://claude.ai/code)