### PR TITLE
fix(sticker-catalogue): oauth config for compose environments 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -285,6 +285,11 @@ services:
     environment:
       # Quarkus profile - use prod-kafka for Kafka messaging
       QUARKUS_PROFILE: prod-kafka
+      # OAuth/JWT configuration
+      # OAUTH_ISSUER: Expected issuer claim in JWT tokens (external URL that user-management advertises)
+      OAUTH_ISSUER: ${DEPLOYMENT_HOST_URL:-http://localhost:8080}/
+      # MP_JWT_VERIFY_PUBLICKEY_LOCATION: Internal URL to fetch JWKS for signature verification
+      MP_JWT_VERIFY_PUBLICKEY_LOCATION: http://user-management:8080/.well-known/jwks
       # DataDog APM configuration
       DD_SERVICE: sticker-catalogue
       DD_ENV: development

--- a/e2e/tests/authenticated/catalogue.spec.ts
+++ b/e2e/tests/authenticated/catalogue.spec.ts
@@ -23,6 +23,17 @@ test.describe('Sticker Catalogue', () => {
     expect(count).toBeGreaterThan(0);
   });
 
+  test('authenticated API call returns 200', async ({ page }) => {
+    const responsePromise = page.waitForResponse(
+      resp => resp.url().includes('/api/stickers/v1/') && resp.request().method() === 'GET'
+    );
+
+    await catalogue.goto();
+
+    const response = await responsePromise;
+    expect(response.status()).toBe(200);
+  });
+
   test('sticker cards show name, image, and description', async () => {
     await catalogue.waitForStickersLoaded();
 


### PR DESCRIPTION
When I setup the token validation for sticker-catalogue, I was evidently only testing on aws, and the local compose configuration went missing. This fixes that. Validated on codespaces and local dev. 

Without this we get a 401 trying to verify the token, because the `iss` claim does not match anything, because we haven't told the catalogue service what to expect. 