### PR TITLE
feat: add configurable DD env vars

### DIFF
--- a/print-service/infra/aws/lib/print-service-stack.ts
+++ b/print-service/infra/aws/lib/print-service-stack.ts
@@ -49,7 +49,12 @@ export class PrintServiceStack extends cdk.Stack {
       cluster,
       ddApiKey,
       ddApiKeyParam,
-      ddSite
+      ddSite,
+      true,
+      {
+        DD_APM_IGNORE_RESOURCES:
+          "(GET|HEAD) .*/health$,POST localhost:4317/opentelemetry.proto.collector.trace.v1.TraceService/Export,POST localhost:4317/opentelemetry.proto.collector.metrics.v1.MetricsService/Export",
+      },
     );
 
     const serviceProps: ServiceProps = {

--- a/shared/lib/shared-constructs/lib/shared-props.ts
+++ b/shared/lib/shared-constructs/lib/shared-props.ts
@@ -40,7 +40,8 @@ export class SharedProps {
     ddApiKey: string,
     ddApiKeyParam: IStringParameter,
     ddSite: string | undefined = undefined,
-    enableDatadog: boolean = true
+    enableDatadog: boolean = true,
+    datadogAgentEnvironmentVariables: { [key: string]: string } = {}
   ) {
     const environment = process.env.ENV || "dev";
     const deployMode = process.env.DEPLOY_MODE;
@@ -81,7 +82,7 @@ export class SharedProps {
         site: ddSite ?? "datadoghq.com",
         clusterName: cluster.clusterName,
         environmentVariables: {
-          DD_APM_IGNORE_RESOURCES: "(GET|HEAD) .*/health$",
+          ...datadogAgentEnvironmentVariables,
           DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT: "0.0.0.0:4317",
           DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT: "0.0.0.0:4318",
           DD_LOGS_INJECTION: "true",

--- a/sticker-award/infra/aws/lib/sticker-award-service-stack.ts
+++ b/sticker-award/infra/aws/lib/sticker-award-service-stack.ts
@@ -62,6 +62,11 @@ export class StickerAwardServiceStack extends cdk.Stack {
       ddApiKey,
       ddApiKeyParam,
       ddSite,
+      true,
+      {
+        DD_APM_IGNORE_RESOURCES:
+          "(GET|HEAD) .*/health$",
+      }
     );
 
     // Create formatted database credentials from the shared RDS secret

--- a/sticker-catalogue/infra/aws/lib/sticker-catalogue-stack.ts
+++ b/sticker-catalogue/infra/aws/lib/sticker-catalogue-stack.ts
@@ -58,6 +58,10 @@ export class StickerCatalogueServiceStack extends cdk.Stack {
       ddApiKey,
       ddApiKeyParam,
       ddSite,
+      true,
+      {
+        DD_APM_IGNORE_RESOURCES: "(GET|HEAD) .*/health$",
+      },
     );
 
     // Create formatted database credentials from the shared RDS secret

--- a/user-management/infra/aws/lib/user-service-stack.ts
+++ b/user-management/infra/aws/lib/user-service-stack.ts
@@ -55,6 +55,10 @@ export class UserServiceStack extends cdk.Stack {
       ddApiKey,
       ddApiKeyParam,
       ddSite,
+      true,
+      {
+        DD_APM_IGNORE_RESOURCES: "(GET|HEAD) .*/health$",
+      },
     );
 
     // Create formatted database credentials from the shared RDS secret

--- a/web-backend/infra/aws/lib/web-backend-stack.ts
+++ b/web-backend/infra/aws/lib/web-backend-stack.ts
@@ -47,6 +47,10 @@ export class WebBackendStack extends cdk.Stack {
       ddApiKey,
       ddApiKeyParam,
       ddSite,
+      true,
+      {
+        DD_APM_IGNORE_RESOURCES: "(GET|HEAD) .*/health$",
+      },
     );
 
     const serviceProps = {


### PR DESCRIPTION
.NET services instrumented with OTEL automatically capture the POST request to the OTEL collector for sending trace and metric data. This causes noise in Datadog, and needs to be reduced. 

One way to do that, is by using the `DD_IGNORE_RESOURCES` environment variable. This was hardcoded for a single heatlh endpoint that was applied to all services as part of the `SharedProps`. Need to make this configurable.

This PR allows Datadog agent environment variables to be passed in on a per service basis.