### PR TITLE
Set up code for RUM Profiling

### DIFF
--- a/web-backend/server.js
+++ b/web-backend/server.js
@@ -363,7 +363,8 @@ app.use('/api/app/proxy', requireAuth, async (req, res) => {
       headers: {
         'Authorization': `Bearer ${req.session.tokens.access_token}`,
         'Content-Type': req.headers['content-type'] || 'application/json',
-        'Accept': req.headers.accept || 'application/json'
+        'Accept': req.headers.accept || 'application/json',
+        'Document Policy': `js-profiling`
       },
       body: req.method !== 'GET' && req.method !== 'HEAD' ? JSON.stringify(req.body) : undefined
     })

--- a/web-frontend/src/services/DatadogRum.js
+++ b/web-frontend/src/services/DatadogRum.js
@@ -46,6 +46,8 @@ export const initializeDatadogRum = () => {
     trackLongTasks: true,
     defaultPrivacyLevel: 'mask-user-input',
     allowedTracingUrls: [(url) => true],
+    // for RUM Profiling - currently feature flagged
+    profilingSampleRate: 100,
     // TODO - turn this on if we start using the react router!
     //plugins: [reactPlugin({ router: true })],
   });


### PR DESCRIPTION
Talked to the RUM PM and got the feature flag for RUM Profiling enabled for the advocacy org. 

This PR addresses the setup code from [the confluence page](https://datadoghq.atlassian.net/wiki/spaces/PROF/pages/4852777498/Browser+Profiler+f.k.a.+RUM+Profiler#Setup) .

We might need to set up CORS, won't know till it's deployed and testable.