### PR TITLE
chore: fix some missing service name tags

### DIFF
--- a/print-service/infra/aws/lib/constructs/instrumented-function.ts
+++ b/print-service/infra/aws/lib/constructs/instrumented-function.ts
@@ -71,6 +71,7 @@ export class InstrumentedLambdaFunction extends Construct {
       },
       environment: {
         AWS_LAMBDA_EXEC_WRAPPER: "/opt/datadog_wrapper",
+        DD_SERVICE: props.sharedProps.serviceName,
         POWERTOOLS_SERVICE_NAME: props.sharedProps.serviceName,
         POWERTOOLS_LOG_LEVEL:
           (props.logLevel ?? props.sharedProps.environment === "prod")

--- a/user-management/infra/aws/lib/constructs/instrumented-function.ts
+++ b/user-management/infra/aws/lib/constructs/instrumented-function.ts
@@ -71,6 +71,7 @@ export class InstrumentedLambdaFunction extends Construct {
       },
       environment: {
         AWS_LAMBDA_EXEC_WRAPPER: "/opt/datadog_wrapper",
+        DD_SERVICE: props.sharedProps.serviceName,
         POWERTOOLS_SERVICE_NAME: props.sharedProps.serviceName,
         POWERTOOLS_LOG_LEVEL:
           (props.logLevel ?? props.sharedProps.environment === "prod")


### PR DESCRIPTION
Add `DD_SERVICE` environment variable to Lambda function constructs (user-management, print-service) so the Datadog tracer  uses the correct service name instead of falling back to the AWS function name or .NET assembly name
