### PR TITLE
fix: dotnet connstring unsafe chars

### DIFF
--- a/shared/infra/aws/lib/persistence.ts
+++ b/shared/infra/aws/lib/persistence.ts
@@ -43,7 +43,7 @@ export class Persistence extends Construct {
 
     var secret = new DatabaseSecret(this, "SharedDBSecret", {
       username: "postgres",
-      excludeCharacters: '"@/\\',
+      excludeCharacters: '"@/\\;=\'',
     });
 
     // Use DESTROY for dev environments, RETAIN for production


### PR DESCRIPTION
I hit an error deploying user-service to AWS this morning, and it looks like it was due to some remaining unsafe chars in the DB string. 
