### PR TITLE
feat: add client-credentials OAuth flow for API testing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -642,6 +642,7 @@ services:
       KAFKA__SCHEMAREGISTRY: "http://kafka:8082"
       KAFKA__GROUPID: "stickerlandia-user-management"
       DEPLOYMENT_HOST_URL: ${DEPLOYMENT_HOST_URL}
+      APITESTING_CLIENT_SECRET: stickerlandia-api-testing-secret-2025
     command: ["migrations/Stickerlandia.UserManagement.MigrationService.dll"]
 
   web-backend:

--- a/user-management/infra/aws/lib/user-service-stack.ts
+++ b/user-management/infra/aws/lib/user-service-stack.ts
@@ -15,6 +15,7 @@ import {
 import { MigrationTask } from "../../../../shared/lib/shared-constructs/lib/migration-task";
 import { Api } from "./api";
 import { Cluster, Secret } from "aws-cdk-lib/aws-ecs";
+import * as secretsmanager from "aws-cdk-lib/aws-secretsmanager";
 import * as path from "path";
 import { BackgroundWorkers } from "./background-workers";
 import { StringParameter } from "aws-cdk-lib/aws-ssm";
@@ -73,6 +74,19 @@ export class UserServiceStack extends cdk.Stack {
       createSsmParameterReferences: false,
     });
 
+    // Secret for the api-testing OAuth client (used by Datadog Synthetics)
+    const apiTestingClientSecret = new secretsmanager.Secret(
+      this,
+      "ApiTestingClientSecret",
+      {
+        secretName: `/stickerlandia/${environment}/api-testing-client-secret`,
+        generateSecretString: {
+          excludePunctuation: true,
+          passwordLength: 48,
+        },
+      },
+    );
+
     // Run database migrations before starting services
     const migrationTask = new MigrationTask(this, "MigrationTask", {
       sharedProps: sharedProps,
@@ -98,6 +112,9 @@ export class UserServiceStack extends cdk.Stack {
       secrets: {
         ConnectionStrings__database:
           dbCredentials.getConnectionStringEcsSecret()!,
+        APITESTING_CLIENT_SECRET: Secret.fromSecretsManager(
+          apiTestingClientSecret,
+        ),
       },
       // Use the same security group as the API service for consistent network access
       securityGroupId: sharedResources.vpcLinkSecurityGroupId,
@@ -160,6 +177,12 @@ export class UserServiceStack extends cdk.Stack {
     new cdk.CfnOutput(this, "ServiceApiUrl", {
       value: `${sharedResources.domainName}/api/users/v1`,
       description: "User Management Service API URL",
+    });
+
+    new cdk.CfnOutput(this, "ApiTestingClientSecretArn", {
+      value: apiTestingClientSecret.secretArn,
+      description:
+        "ARN of the Secrets Manager secret for the api-testing OAuth client",
     });
   }
 }

--- a/user-management/infra/azure/variables.tf
+++ b/user-management/infra/azure/variables.tf
@@ -31,3 +31,16 @@ variable "dd_site" {
   default = "datadoghq.com"
   description = "The Datadog site"
 }
+
+# Secret for the api-testing OAuth client (used by Datadog Synthetics).
+# Inject as APITESTING_CLIENT_SECRET into the migration service environment.
+resource "random_password" "api_testing_client_secret" {
+  length  = 48
+  special = false
+}
+
+output "api_testing_client_secret" {
+  value     = random_password.api_testing_client_secret.result
+  sensitive = true
+  description = "Secret for the api-testing OAuth client (pass to Datadog Synthetics)"
+}

--- a/user-management/src/Stickerlandia.UserManagement.Api/Controllers/AuthorizationController.cs
+++ b/user-management/src/Stickerlandia.UserManagement.Api/Controllers/AuthorizationController.cs
@@ -289,6 +289,30 @@ public class AuthorizationController(
             return SignIn(new ClaimsPrincipal(identity), OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
         }
 
+        if (request.IsClientCredentialsGrantType())
+        {
+            // Client credentials flow: application-level authentication (no user context).
+            // Used for service-to-service calls such as Datadog Synthetics API testing.
+            var application = await applicationManager.FindByClientIdAsync(request.ClientId!) ??
+                throw new InvalidOperationException("The client application cannot be found.");
+
+            var identity = new ClaimsIdentity(
+                TokenValidationParameters.DefaultAuthenticationType,
+                OpenIddictConstants.Claims.Name,
+                OpenIddictConstants.Claims.Role);
+
+            identity.SetClaim(OpenIddictConstants.Claims.Subject, request.ClientId);
+            identity.SetClaim(OpenIddictConstants.Claims.Name, request.ClientId);
+            identity.SetClaims(OpenIddictConstants.Claims.Role, ["api-testing"]);
+
+            identity.SetScopes(request.GetScopes());
+            identity.SetResources(await scopeManager.ListResourcesAsync(identity.GetScopes()).ToListAsync());
+            identity.SetAudiences("stickerlandia");
+            identity.SetDestinations(GetDestinations);
+
+            return SignIn(new ClaimsPrincipal(identity), OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
+        }
+
         throw new InvalidOperationException("The specified grant type is not supported.");
     }
 

--- a/user-management/src/Stickerlandia.UserManagement.Auth/AuthServiceExtensions.cs
+++ b/user-management/src/Stickerlandia.UserManagement.Auth/AuthServiceExtensions.cs
@@ -47,7 +47,8 @@ public static class AuthServiceExtensions
                 // the other flows if you need to support implicit, password or client credentials.
                 options.AllowAuthorizationCodeFlow()
                     .RequireProofKeyForCodeExchange()
-                    .AllowRefreshTokenFlow();
+                    .AllowRefreshTokenFlow()
+                    .AllowClientCredentialsFlow();
 
                 // Register the signing and encryption credentials.
                 options.AddDevelopmentEncryptionCertificate()

--- a/user-management/src/Stickerlandia.UserManagement.MigrationService/Worker.cs
+++ b/user-management/src/Stickerlandia.UserManagement.MigrationService/Worker.cs
@@ -131,7 +131,40 @@ internal sealed class Worker(
             seedData?.SetTag("oauth.web-ui.redirectUri", redirectUri.ToString());
         }
 
-        // As soon as Stickerlandia services need to call other services under their own identities, add them here
+        // api-testing client: used for service-to-service calls (e.g. Datadog Synthetics API testing).
+        // Uses the client_credentials OAuth flow — no user context, no redirect URIs.
+        var apiTestingSecret = Environment.GetEnvironmentVariable("APITESTING_CLIENT_SECRET")
+            ?? "stickerlandia-api-testing-secret-2025";
+
+        var existingApiTestingClient = await manager.FindByClientIdAsync("api-testing", cancellationToken);
+        if (existingApiTestingClient is null)
+        {
+            await manager.CreateAsync(new OpenIddictApplicationDescriptor
+            {
+                ClientId = "api-testing",
+                ClientSecret = apiTestingSecret,
+                ClientType = OpenIddictConstants.ClientTypes.Confidential,
+                ConsentType = OpenIddictConstants.ConsentTypes.Implicit,
+                Permissions =
+                {
+                    OpenIddictConstants.Permissions.Endpoints.Token,
+                    OpenIddictConstants.Permissions.GrantTypes.ClientCredentials,
+                    OpenIddictConstants.Permissions.Scopes.Roles
+                }
+            }, cancellationToken);
+
+            seedData?.SetTag("oauth.api-testing.created", true);
+        }
+        else
+        {
+            // Update existing client to ensure secret matches (cloud-provided secret may have changed)
+            var descriptor = new OpenIddictApplicationDescriptor();
+            await manager.PopulateAsync(descriptor, existingApiTestingClient, cancellationToken);
+            descriptor.ClientSecret = apiTestingSecret;
+            await manager.UpdateAsync(existingApiTestingClient, descriptor, cancellationToken);
+
+            seedData?.SetTag("oauth.api-testing.updated", true);
+        }
 
         // Seed default user
         try


### PR DESCRIPTION
This'll let us exchange client credentials for a bearer token we can use for synthetics testing of the APIs.
